### PR TITLE
Removed L4D2 from badExes

### DIFF
--- a/Util.cs
+++ b/Util.cs
@@ -20,7 +20,7 @@ namespace LiveSplit.SourceSplit
             // http://forums.steampowered.com/forums/showthread.php?t=2465755
             // http://en.wikipedia.org/wiki/Valve_Anti-Cheat#Games_that_support_VAC
             string[] badExes = { "csgo", "dota2", "swarm", "left4dead",
-                "left4dead2", "dinodday", "insurgency", "nucleardawn", "ship" };
+                "dinodday", "insurgency", "nucleardawn", "ship" };
             string[] badMods = { "cstrike", "dods", "hl2mp", "insurgency", "tf", "zps" };
             string[] badRootDirs = { "Dark Messiah of Might and Magic Multi-Player" };
 


### PR DESCRIPTION
According to multiple threads, VAC bans are served on a Memory Write basis. Memory read appears to be safe (What SourceSplits does).

So I removed L4D2 as I can confirm that the code does in fact split/pause/start correctly on map changes and loads