### PR TITLE
Updated for compatibility with LiveSplit 1.8+

### DIFF
--- a/LiveSplit.SourceSplit.csproj
+++ b/LiveSplit.SourceSplit.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LiveSplit.SourceSplit</RootNamespace>
     <AssemblyName>LiveSplit.SourceSplit</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/SourceSplitComponent.cs
+++ b/SourceSplitComponent.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using LiveSplit.Model;
+using LiveSplit.Options;
 using LiveSplit.TimeFormatters;
 using LiveSplit.UI.Components;
 using LiveSplit.UI;
@@ -392,10 +393,11 @@ namespace LiveSplit.SourceSplit
             // make split times accurate
             _timer.CurrentState.SetGameTime(this.GameTime);
 
-            bool before = _timer.CurrentState.Settings.DoubleTapPrevention;
-            _timer.CurrentState.Settings.DoubleTapPrevention = false;
+            HotkeyProfile profile = _timer.CurrentState.Settings.HotkeyProfiles[_timer.CurrentState.CurrentHotkeyProfile];
+            bool before = profile.DoubleTapPrevention;
+            profile.DoubleTapPrevention = false;
             _timer.Split();
-            _timer.CurrentState.Settings.DoubleTapPrevention = before;
+            profile.DoubleTapPrevention = before;
         }
 
         // TODO: asterisk for manual start and splits


### PR DESCRIPTION
Needed to update .NET to 4.6.1 as that's what LiveSplit was built with. Simple fix.